### PR TITLE
imx6ul-oas.dts: Add mfgtool generated device tree

### DIFF
--- a/arch/arm/boot/dts/imx6ul-oas.dts
+++ b/arch/arm/boot/dts/imx6ul-oas.dts
@@ -1,279 +1,300 @@
 /*
- * Copyright 2016 Digi International, Inc.
+ * Device tree generated automatically by Digi ConnectCore Smart IOmux.
  *
- * The code contained herein is licensed under the GNU General Public
- * License. You may obtain a copy of the GNU General Public License
- * Version 2 or later at the following locations:
- *
- * http://www.opensource.org/licenses/gpl-license.html
- * http://www.gnu.org/copyleft/gpl.html
+ * This file is provided "AS IS" without any warranties and support.
+ * Please verify the pin assignation with the hardware reference manual.
  */
 
 /dts-v1/;
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/interrupt-controller/irq.h>
+
 /* i.MX6 UltraLite CPU */
 #include "imx6ul.dtsi"
 /* ConnectCore 6UL (wireless/bluetooth variant) */
 #include "imx6ul-ccimx6ul-wb.dtsi"
-/* ConnectCore 6UL SBC */
-#include "imx6ul-ccimx6ulsbc.dtsi"
 
-/*
- * Uncomment to enable the i.MX6UL SoC ADCs on the GPIO connector:
- *  - EXP_GPIO_1 (channel 5)
- *  - EXP_GPIO_2 (channel 3)
- *  - EXP_GPIO_3 (channel 2)
- * Include in adc-ch-list the ADC channels (from 0 to 9) that you want to
- * enable. Note that the iomux has to be configured accordingly in pinctrl_adc1
- * to configure the pad for ADC operation
- */
-&adc1 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_adc1>;
-	adc-ch-list = <2>;
-	status = "okay";
+/ {
+    // Add here your platform model.
+    model = "ConnectCore 6UL";
+
+    // Add here your compatible platform.
+    compatible = "digi,ccimx6ul", "fsl,imx6ul";
 };
 
-&caam_keyblob {
-	status = "okay";
-};
-
-/*
- * CSI camera conflicts with microSD/eMMC.
- * Before enabling the camera you need to disable
- * usdhc2 node.
- */
-// &csi {
-//	status = "okay";
-// };
-
-/* ECSPI1 (as master) */
-&ecspi1 {
-	status = "okay";
-
-	/*
-	 * Add your slave devices here. Next is an example of spidev.
-	 * Expect a harmless kernel warning if you enable spidev as slave.
-	 */
-	spidev@0 {
-		reg = <0>;
-		compatible = "spidev";
-		spi-max-frequency = <1000000>;
-	};
-};
-
-/* ENET1 */
-&fec1 {
-	status = "okay";
-};
-
-/* ENET2 */
-&fec2 {
-	status = "okay";
-};
-
-/* CAN1 (multiplexed with UART3 RTS/CTS) */
 &can1 {
-	status = "okay";
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_flexcan1>;
+
+    /*
+     * Optional field.
+     *
+     * Set the proper voltage regulator to power the
+     * transceiver if needed.
+     */
+    xceiver-supply = <&ext_3v3>;
+
+    status = "okay";
 };
 
-/* CAN2 (multiplexed with UART2 RTS/CTS) */
-&can2 {
-	status = "okay";
+&ecspi1 {
+    fsl,spi-num-chipselects = <1>;
+    pinctrl-names = "default";
+    status = "okay";
+
+    /*
+     * ECSPI1 (as master)
+     */
+    pinctrl-0 = <&pinctrl_ecspi1>;
 };
 
-/* Uncomment to enable fusion touch */
-//&fusion_touch {
-//	status = "okay";
-//};
+&fec2 {
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_enet2 &pinctrl_enet_mdio>;
+    phy-mode = "rmmi";
+    phy-handle = <&ethphy2>;
 
-/*
- * Goodix touch
- * On the CC6UL SBC, an inconsistent reset sequence makes the
- * Goodix display's touch controller respond to two I2C
- * addresses: 0x14 and 0x5D. To make sure the touchscreen
- * works every time, the touch controller's description must
- * be duplicated for both addresses. This is why there are two
- * entries for the Goodix touch.
- */
-&goodix_touch1 {
-	status = "okay";
+    /*
+     * Optional fields.
+     *
+     * Configure the phy reset with a GPIO in your design.
+     */
+    //phy-reset-gpios = <&gpio5 6 GPIO_ACTIVE_LOW>
+    //phy-reset-duration = <26>;
+    //digi,phy-reset-in-suspend;
+
+    status = "okay";
+
+    mdio {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        ethphy2: ethernet-phy@1 {
+            compatible = "ethernet-phy-ieee802.3-c22";
+
+            /*
+             * Add your custom PHY configuration.
+             */
+            //smsc,disable-energy-detect;
+            reg = <1>;
+        };
+    };
 };
 
-&goodix_touch2 {
-	status = "okay";
+&i2c2 {
+    clock-frequency = <100000>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_i2c2>;
+    status = "okay";
 };
 
-/* Parallel LCD */
-&lcdif {
-	status = "okay";
+&i2c3 {
+    clock-frequency = <100000>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_i2c3>;
+    status = "okay";
 };
 
-/* LCD backlight (PWM5) */
-&lcd_backlight {
-	status = "okay";
+&sai3 {
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_sai3>;
+    status = "okay";
 };
 
-&max98089 {
-	status = "okay";
-};
-
-/*
- * Uncomment to enable MCA ADC channels on GPIO connector:
- *  - MCA_IO1 (channel 1)
- *  - MCA_IO3 (channel 3)
- * Edit adc-ch-list to include the ADC channels that you want to enable.
- */
-// &mca_adc {
-// 	digi,adc-ch-list = <1 3>;
-// 	digi,adc-vref = <3000000>;
-// };
-
-/*
- * Uncomment to enable MCA UART:
- *  - MCA_IO1 (TX)
- *  - MCA_IO2 (RX)
- */
-//&mca_uart {
-//	status = "okay";
-//
-//	/* Uncomment to enable CTS and/or RTS in any MCA GPIO-capable line */
-//	//rts-pin = <3>;
-//	//cts-pin = <5>;
-//};
-
-&mca_ioexp {
-	status = "okay";
-	restore-config-on-resume;
-};
-
-/*
- * Uncomment to enable the I/O Expander ADCs on GPIO connector:
- *  - IOEXP_3 (channel 3)
- *  - IOEXP_4 (channel 4)
- *  - IOEXP_5 (channel 5)
- * Include in adc-ch-list the ADC channels that you want to enable.
- */
-// &mca_ioexp_adc {
-// 	digi,adc-ch-list = <3 4 5>;
-// 	digi,adc-vref = <3300000>;
-// };
-
-/* Uncomment to Enable Tamper detection. There are 2 digital (0 and 1) and 2
- * analog (2 and 3) tamper interfaces.
- */
-//&mca_tamper {
-//	digi,tamper-if-list = <0 1 2 3>;
-//};
-
-/*
- * CSI camera conflicts with microSD/eMMC.
- * Before enabling the camera you need to disable
- * usdhc2 node.
- */
-// &ov5642 {
-//	status = "okay";
-// };
-
-/*
- * To use CSI camera with suspend/resume, uncomment ext_3v3
- * regulator to leave it ON in suspend
- */
-//&ext_3v3 {
-//	regulator-state-mem {
-//		regulator-on-in-suspend;
-//	};
-//};
-
-/* PWM4 on pin 11 of GPIO connector */
-&pwm4 {
-	status = "okay";
-};
-
-&pwm5 {
-	status = "okay";
-};
-
-&pxp {
-	status = "okay";
-};
-
-&pxp_v4l2 {
-	status = "okay";
-};
-
-&sai2 {
-	status = "okay";
-};
-
-&sound_max98089 {
-	status = "okay";
-};
-
-/* UART2 */
 &uart2 {
-	/* RTS/CTS lines multiplexed with CAN2 */
-	// pinctrl-0 = <&pinctrl_uart2_4wires>;
-	// uart-has-rtscts;
-	status = "okay";
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_uart2>;
+    status = "okay";
 };
 
-/* UART3 */
-&uart3 {
-	/* RTS/CTS lines multiplexed with CAN1 */
-	// pinctrl-0 = <&pinctrl_uart3_4wires>;
-	// uart-has-rtscts;
-	status = "okay";
-};
-
-/* UART5 (Console) */
 &uart5 {
-	status = "okay";
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_console>;
+    status = "okay";
 };
 
 &usbotg1 {
-	status = "okay";
+    dr_mode = "peripheral";
+
+    /*
+     * Set the proper voltage regulator to power the
+     * vbus if needed.
+     */
+    //vbus-supply = <&reg_usb_otg1_vbus>;
+    status = "okay";
 };
 
 &usbotg2 {
-	status = "okay";
+    dr_mode = "host";
+
+    /*
+     * Set the proper voltage regulator to power the
+     * vbus if needed.
+     */
+    //vbus-supply = <&reg_usb_otg1_vbus>;
+
+    /*
+     * Configure the power line if needed.
+     */
+    //fsl,power-line-polarity-active-high;
+
+    /*
+     * Configure the overcurrent line if needed.
+     */
+    //fsl,over-current-polarity-active-low;
+    //disable-over-current;
+    pinctrl-0 = <&pinctrl_usbotg2>;
+    status = "okay";
 };
 
-/* USDHC2 (microSD, conflicts with eMMC) */
 &usdhc2 {
-	pinctrl-assert-gpios = <&gpio5 1 GPIO_ACTIVE_LOW>;
-	broken-cd;	/* no carrier detect line (use polling) */
-	status = "okay";
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_usdhc2>;
+    no-1-8-v;
+    status = "okay";
 };
 
-/* USDHC2 (eMMC, conflicts with microSD) */
-//&usdhc2 {
-//	pinctrl-assert-gpios = <&gpio5 1 GPIO_ACTIVE_HIGH>;
-//	non-removable;
-//	/*
-//	 * Comment these two lines for 4-bit data bus or leave uncommented
-//	 * for 8-bit data bus
-//	 */
-//	pinctrl-0 = <&pinctrl_usdhc2_8databits>;
-//	bus-width = <8>;
-//
-//	status = "okay";
-//};
-
-/* Pin mux configuration */
 &iomuxc {
-	imx6ul-ccimx6ul {
-		/* Uncomment specific pins of the ADC channels enabled in 'adc-ch-list' */
-		pinctrl_adc1: adc1grp {
-			fsl,pins = <
-		//		/* EXP_GPIO_1 -> GPIO1_5/ADC1_IN5 */
-		//		MX6UL_PAD_GPIO1_IO05__GPIO1_IO05        0xb0
-		//		/* EXP_GPIO_2 -> GPIO1_3/ADC1_IN3 */
-		//		MX6UL_PAD_GPIO1_IO03__GPIO1_IO03        0xb0
-				/* EXP_GPIO_3 -> GPIO1_2/ADC1_IN2 */
-				MX6UL_PAD_GPIO1_IO02__GPIO1_IO02        0xb0
-			>;
-		};
-	};
+    pinctrl-0 = <&pinctrl_hog>;
+
+    imx6ul-ccimx6ul {
+        pinctrl_console: uart5grp {
+            fsl,pins = <
+                MX6UL_PAD_UART5_RX_DATA__UART5_DCE_RX		0x1b0b1
+                MX6UL_PAD_UART5_TX_DATA__UART5_DCE_TX		0x1b0b1
+            >;
+        };
+
+        pinctrl_ecspi1: ecspi1grp1 {
+            fsl,pins = <
+                MX6UL_PAD_LCD_DATA22__ECSPI1_MOSI		0x10b0
+                MX6UL_PAD_LCD_DATA23__ECSPI1_MISO		0x10b0
+                MX6UL_PAD_LCD_DATA12__ECSPI1_RDY		0x10b0
+                MX6UL_PAD_LCD_DATA20__ECSPI1_SCLK		0x10b0
+            >;
+        };
+
+        pinctrl_enet2: enet2grp {
+            fsl,pins = <
+                MX6UL_PAD_ENET2_RX_DATA0__ENET2_RDATA00		0x1b0b0
+                MX6UL_PAD_ENET2_RX_DATA1__ENET2_RDATA01		0x1b0b0
+                MX6UL_PAD_UART3_CTS_B__ENET2_RX_CLK		0x40017051
+                MX6UL_PAD_ENET2_RX_EN__ENET2_RX_EN		0x1b0b0
+                MX6UL_PAD_ENET2_RX_ER__ENET2_RX_ER		0x1b0b0
+                MX6UL_PAD_ENET2_TX_DATA0__ENET2_TDATA00		0x1b0b0
+                MX6UL_PAD_ENET2_TX_DATA1__ENET2_TDATA01		0x1b0b0
+                MX6UL_PAD_ENET2_TX_CLK__ENET2_TX_CLK		0x40017051
+                MX6UL_PAD_ENET2_TX_EN__ENET2_TX_EN		0x1b0b0
+                MX6UL_PAD_UART3_RTS_B__ENET2_TX_ER		0x1b0b0
+            >;
+        };
+
+        pinctrl_enet_mdio: mdioenetgrp {
+            fsl,pins = <
+                MX6UL_PAD_GPIO1_IO07__ENET2_MDC		0x1b0b0
+                MX6UL_PAD_GPIO1_IO06__ENET2_MDIO		0x1b0b0
+            >;
+        };
+
+        pinctrl_flexcan1: flexcan1grp {
+            fsl,pins = <
+                MX6UL_PAD_ENET1_RX_DATA1__FLEXCAN1_RX		0x1b020
+                MX6UL_PAD_ENET1_RX_DATA0__FLEXCAN1_TX		0x1b020
+            >;
+        };
+
+        pinctrl_hog: hoggrp {
+            fsl,pins = <
+                /* gpio_id_0 */
+                MX6UL_PAD_GPIO1_IO05__GPIO1_IO05		0x10b0
+                /* gpio_id_1 */
+                MX6UL_PAD_GPIO1_IO08__GPIO1_IO08		0x10b0
+                /* gpio_id_2 */
+                MX6UL_PAD_GPIO1_IO09__GPIO1_IO09		0x10b0
+                /* gpio_id_3 */
+                MX6UL_PAD_SNVS_TAMPER1__GPIO5_IO01		0x10b0
+                /* gpio_id_4 */
+                MX6UL_PAD_SNVS_TAMPER2__GPIO5_IO02		0x10b0
+                /* gpio_id_5 */
+                MX6UL_PAD_SNVS_TAMPER5__GPIO5_IO05		0x10b0
+                /* gpio_id_6 */
+                MX6UL_PAD_SNVS_TAMPER6__GPIO5_IO06		0x10b0
+                /* gpio_id_7 */
+                MX6UL_PAD_SNVS_TAMPER7__GPIO5_IO07		0x10b0
+                /* gpio_id_8 */
+                MX6UL_PAD_SNVS_TAMPER8__GPIO5_IO08		0x10b0
+                /* gpio_id_9 */
+                MX6UL_PAD_GPIO1_IO03__GPIO1_IO03		0x10b0
+                /* gpio_id_10 */
+                MX6UL_PAD_LCD_DATA21__GPIO3_IO26		0x10b0
+                /* gpio_id_11 */
+                MX6UL_PAD_GPIO1_IO00__GPIO1_IO00		0x10b0
+                /* gpio_id_12 */
+                MX6UL_PAD_GPIO1_IO01__GPIO1_IO01		0x10b0
+                /* gpio_id_13 */
+                MX6UL_PAD_GPIO1_IO04__GPIO1_IO04		0x10b0
+                /* gpio_id_14 */
+                MX6UL_PAD_JTAG_MOD__GPIO1_IO10		0x10b0
+                /* gpio_id_15 */
+                MX6UL_PAD_JTAG_TMS__GPIO1_IO11		0x10b0
+                /* gpio_id_16 */
+                MX6UL_PAD_JTAG_TDO__GPIO1_IO12		0x10b0
+                /* gpio_id_17 */
+                MX6UL_PAD_JTAG_TDI__GPIO1_IO13		0x10b0
+                /* gpio_id_18 */
+                MX6UL_PAD_JTAG_TCK__GPIO1_IO14		0x10b0
+                /* gpio_id_19 */
+                MX6UL_PAD_JTAG_TRST_B__GPIO1_IO15		0x10b0
+                /* gpio_id_20 */
+                MX6UL_PAD_UART2_CTS_B__GPIO1_IO22		0x10b0
+            >;
+        };
+
+        pinctrl_i2c2: i2c2grp {
+            fsl,pins = <
+                MX6UL_PAD_CSI_HSYNC__I2C2_SCL		0x4001b8b0
+                MX6UL_PAD_CSI_VSYNC__I2C2_SDA		0x4001b8b0
+            >;
+        };
+
+        pinctrl_i2c3: i2c3grp {
+            fsl,pins = <
+                MX6UL_PAD_LCD_DATA01__I2C3_SCL		0x4001b8b0
+                MX6UL_PAD_LCD_DATA00__I2C3_SDA		0x4001b8b0
+            >;
+        };
+
+        pinctrl_sai3: sai3grp {
+            fsl,pins = <
+                MX6UL_PAD_LCD_CLK__SAI3_MCLK		0x17088
+                MX6UL_PAD_LCD_DATA11__SAI3_RX_BCLK		0x1b030
+                MX6UL_PAD_LCD_DATA14__SAI3_RX_DATA		0x11088
+                MX6UL_PAD_LCD_DATA13__SAI3_TX_BCLK		0x17088
+                MX6UL_PAD_LCD_DATA15__SAI3_TX_DATA		0x11088
+                MX6UL_PAD_LCD_ENABLE__SAI3_TX_SYNC		0x17088
+            >;
+        };
+
+        pinctrl_uart2: uart2grp {
+            fsl,pins = <
+                MX6UL_PAD_UART2_RX_DATA__UART2_DCE_RX		0x1b0b1
+                MX6UL_PAD_UART2_TX_DATA__UART2_DCE_TX		0x1b0b1
+            >;
+        };
+
+        pinctrl_usbotg2: usbotg2grp {
+            fsl,pins = <
+                MX6UL_PAD_GPIO1_IO02__USB_OTG2_PWR		0x17059
+            >;
+        };
+
+        pinctrl_usdhc2: usdhc2grp {
+            fsl,pins = <
+                MX6UL_PAD_LCD_DATA19__USDHC2_CLK		0x10039
+                MX6UL_PAD_LCD_DATA18__USDHC2_CMD		0x17059
+                MX6UL_PAD_CSI_DATA00__USDHC2_DATA0		0x17059
+                MX6UL_PAD_CSI_DATA01__USDHC2_DATA1		0x17059
+                MX6UL_PAD_CSI_DATA02__USDHC2_DATA2		0x17059
+                MX6UL_PAD_CSI_DATA03__USDHC2_DATA3		0x17059
+            >;
+        };
+    };
 };


### PR DESCRIPTION
The devicetree tells the Linux kernel about the hardware topology
so that the correct drivers can be loaded and configured.