### PR TITLE
dts: imx6ul-oas: Fix GPIO pinning

### DIFF
--- a/arch/arm/boot/dts/imx6ul-oas.dts
+++ b/arch/arm/boot/dts/imx6ul-oas.dts
@@ -99,24 +99,24 @@
 };
 
 &gpio1 {
-    gpio-line-names = "USB_OTG1_ID","USB_OTG1_OC","USB_HOST_VBUS_ext_ENABLE","HLP_FW_RST_OPU","USB_OTG1_PWR","HLP_FW_RST_CSP","ETH_MDIO","ETH_MDC", // GPIO1_IO00-GPIO1_IO07
-                      "HLP_FW_RST_SUT","HLP_DISCONNECT_SUT","JTAG_MOD","JTAG_TMS","JTAG_TDO","JTAG_TDI","JTAG_TCK","JTAG_TRST_B",                   // GPIO1_IO08-GPIO1_IO15
-                      "","","","","UART2_TX","UART2_RX","USB_HOST_ext_OC_FLAG","HLP_FW_RST_EXTCAN",                                                 // GPIO1_IO16-GPIO1_IO23
-                      "","","","","","","UART5_TX","UART5_RX";                                                                                      // GPIO1_IO24-GPIO1_IO31
+    gpio-line-names = "USB_OTG1_ID","USB_OTG1_OC","USB_HOST_VBUS_ext_ENABLE","USB_HOST_ext_OC_FLAG","USB_OTG1_PWR","HLP_FW_RST_CSP","ETH_MDIO","ETH_MDC", // GPIO1_IO00-GPIO1_IO07
+                      "HLP_FW_RST_SUT","HLP_DISCONNECT_SUT","JTAG_MOD","JTAG_TMS","JTAG_TDO","JTAG_TDI","JTAG_TCK","JTAG_TRST_B",                         // GPIO1_IO08-GPIO1_IO15
+                      "","","","","UART2_TX","UART2_RX","HLP_FW_RST_OPU","HLP_FW_RST_EXTCAN",                                                             // GPIO1_IO16-GPIO1_IO23
+                      "","","","","","","UART5_TX","UART5_RX";                                                                                            // GPIO1_IO24-GPIO1_IO31
 };
 
 &gpio3 {
-    gpio-line-names = "AUDIO.MCLK","AUDIO.TX_SYNC","DSUB_GPIO11","DSUB_GPIO12","","I2C2_SDA","I2C2_SCL","LED_1",    // GPIO3_IO00-GPIO3_IO07
-                      "LED_2","LED_3","P1_running","P2_running","booting","","","",                                 // GPIO3_IO08-GPIO3_IO15
-                      "","","AUDIO.TX_BCLK","AUDIO.RX_DATA","AUDIO.TX_DATA","","microSD.SD_DET","microSD.CMD",      // GPIO3_IO16-GPIO3_IO23
-                      "microSD.CLK","","HLP_ISO_GPIO_SPARE","HLP_I2C_MUTEX","CSP_I2C_MUTEX","","","";               // GPIO3_IO24-GPIO3_IO31
+    gpio-line-names = "AUDIO.MCLK","AUDIO.TX_SYNC","DSUB_GPIO11","DSUB_GPIO12","","I2C2_SDA","I2C2_SCL","LED_1",       // GPIO3_IO00-GPIO3_IO07
+                      "LED_2","LED_3","P1_running","P2_running","booting","","","",                                    // GPIO3_IO08-GPIO3_IO15
+                      "","","AUDIO.TX_BCLK","AUDIO.RX_DATA","AUDIO.TX_DATA","HW_rev_F1","24V_PowerGood","microSD.CMD", // GPIO3_IO16-GPIO3_IO23
+                      "microSD.CLK","","HLP_ISO_GPIO_SPARE","HLP_I2C_MUTEX","CSP_I2C_MUTEX","","","";                  // GPIO3_IO24-GPIO3_IO31
 };
 
 &gpio4 {
     gpio-line-names = "","","","","","","","", // GPIO4_IO00-GPIO4_IO07
                       "","","","","","","","", // GPIO4_IO08-GPIO4_IO15
-                      "","","","I2C1.SDA","I2C1.SCL","microSD.DATA0","microSD.DATA1","microSD.DATA2",               // GPIO4_IO16-GPIO4_IO23
-                      "microSD.DATA3","","","POWER_AMP_CTRL","","","","";                                           // GPIO4_IO24-GPIO4_IO31
+                      "","microSD.SD_DET","","I2C1.SDA","I2C1.SCL","microSD.DATA0","microSD.DATA1","microSD.DATA2",  // GPIO4_IO16-GPIO4_IO23
+                      "microSD.DATA3","HW_rev_F2","HW_rev_F3","POWER_AMP_CTRL","AUDIO.INT","","","";                 // GPIO4_IO24-GPIO4_IO31
 
     audio_amp_control {
         gpio-hog;


### PR DESCRIPTION
Apparently had an old EP5 schematic, so now the pinning should be up
to date with the latest EP5 schematic